### PR TITLE
[Feat] add TContext for ApolloServer generic type

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -5,6 +5,10 @@ import { cors } from '@elysiajs/cors'
 import typeDefs from './schema'
 import resolvers from './resolvers'
 
+interface MyContext {
+    hi: string
+}
+
 const app = new Elysia()
     .use(
         cors({
@@ -12,7 +16,7 @@ const app = new Elysia()
         })
     )
     .use(
-        apollo({
+        apollo<'/graphql', MyContext>({
             path: '/graphql',
             typeDefs,
             resolvers,


### PR DESCRIPTION
# Overview

I've added context generic type, passing through `apollo`, for `ApolloServer`.
So, you can pass your custom context type and work with type on your code editor.

# Screenshots

![Screen Shot 2567-01-14 at 22 35 09](https://github.com/elysiajs/elysia-apollo/assets/6861191/500d70f2-3f8e-4a6b-bafa-9108d8f0bd21)

![Screen Shot 2567-01-14 at 22 35 20](https://github.com/elysiajs/elysia-apollo/assets/6861191/9a04c6cb-c2d0-48af-8742-fb05a1a0f713)


------

I'm not sure if my code is over-engineering or not, please address me.
If you have any feedback or suggestions, please let me know.
