### PR TITLE
Fixed type error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ export class ElysiaApolloServer<
 
         // @ts-ignore
         const landingPage = await landing!.serverWillStart!({}).then((r) =>
+            // @ts-ignore
             r?.renderLandingPage
                 ? r.renderLandingPage().then((r) => r.html)
                 : null


### PR DESCRIPTION
```
error TS2339: Property 'renderLandingPage' does not exist on type 'void | GraphQLServerListener'.
  Property 'renderLandingPage' does not exist on type 'void'.
```
This error occurs when trying to use the plugin