### PR TITLE
Remove deprecated playground option and fix landing page rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Below are the extended parameters for configuring Apollo Server with Elysia.
 
 Path to expose Apollo Server
 
-### enablePlayground
-@default "process.env.ENV !== 'production'
+### landingPage
+@default "process.env.ENV === 'production' ? 'Production' : 'Local'"
 
-Determine whether should Apollo should provide Apollo Playground
+Determine whether should Apollo render landing page with a `'Local'` variation, `'Production'` variation, or completely `'Disabled'` it. Read more information about each variation on [Apollo's Landing Page Plugins](https://www.apollographql.com/docs/apollo-server/api/plugin/landing-pages)

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,12 @@ export class ElysiaApolloServer<
 			{}
 		).then((r) =>
 			r?.renderLandingPage
-				? r.renderLandingPage().then((r) => r.html)
+				? // @ts-ignore
+					r
+						.renderLandingPage()
+						.then(({ html }) =>
+							typeof html === 'string' ? html : html()
+						)
 				: null
 		)
 
@@ -64,7 +69,7 @@ export class ElysiaApolloServer<
 		if (landingPageHtml)
 			app.get(
 				path,
-				new Response(landingPageHtml as string, {
+				new Response(landingPageHtml, {
 					headers: {
 						'Content-Type': 'text/html'
 					}


### PR DESCRIPTION
resolve #9 

## What's in this PR
- Remove deprecated GraphQL Playground package as [it was retired](https://github.com/graphql/graphql-playground/issues/1143)
- Replace `enablePlayground` option with `landingPage` option
   - The value can be `'Local' | 'Production' | 'Disabled'` referencing from [Apollo's Landing Page Plugins guide](https://www.apollographql.com/docs/apollo-server/api/plugin/landing-pages)
   - Default value is `process.env.ENV === 'production' ? 'Production' : 'Local'` to keep the behavior the same as [Apollo Server's default behavior](https://www.apollographql.com/docs/apollo-server/api/plugin/landing-pages#default-behavior)
   - I think there are many use cases that developer want to custom this option. For example, I'm working on an Open API project, so using 'Local' playground on production environment can benefit users a lot.
- Fix landing page was rendered as a string of function in Apollo Server v4 since the `html` property returned from `renderLandingPage` [can also be an async function returning a string](https://www.apollographql.com/docs/apollo-server/integrations/plugins-event-reference#renderlandingpage)
- Update README accordingly

**[NOTE] This PR introducing a breaking change!** but I think it makes sense to do so. We should not continue with official announced retired package.

If there is any opinion or suggestion about this PR. Please don't hesitate to response here. I'm not an expert in Elysia just yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced `enablePlayground` boolean configuration with `landingPage` selector, supporting 'Local', 'Production', or 'Disabled' options for enhanced landing page control. Default behavior now automatically derives from your environment.

* **Documentation**
  * Updated configuration parameter documentation to reflect landing page settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->